### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Install Python and other utilities
 RUN apk add --no-cache --update alpine-sdk git wget python3 python3-dev ca-certificates musl-dev libc-dev gcc bash nano linux-headers && \
     python3 -m ensurepip && \
-    pip3 install --upgrade pip setuptools
+    pip3 install --no-cache-dir --upgrade pip setuptools
 
 # Install pm2-logrotate
 RUN pm2 install pm2-logrotate
@@ -13,7 +13,7 @@ RUN pm2 install pm2-logrotate
 COPY requirements.txt requirements.txt
 
 # Install Python requirements
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Make Docker /config volume for optional config file
 VOLUME /config


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size it does not change much but it still helps :).

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 971.41 MB
* Image size after repair: 952.52 MB
* Difference: 18.89 MB (1.94%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,