### PR TITLE
Catch common configuration error, make more readable exception

### DIFF
--- a/modules/tautulli_connector.py
+++ b/modules/tautulli_connector.py
@@ -301,7 +301,10 @@ class TautulliConnector:
         self.base_url = base_url
         self.anon_users = anon_users
         self.api_key = api_key
-        self.api = tautulli.RawAPI(base_url=base_url, api_key=api_key)
+        try:
+            self.api = tautulli.RawAPI(base_url=base_url, api_key=api_key)
+        except Exception as e: # common issue - `base_url` is empty because config was not parsed properly, causes "'NoneType' object has no attribute 'endswith'" error inside Tautulli API library
+            raise Exception(f"Could not begin a Tautulli connection. Please check that your configuration is complete and reachable. Exception: {e}")
         self.server_name = server_name or self.api.server_friendly_name
         self.terminate_message = terminate_message
         self.analytics = analytics


### PR DESCRIPTION
Common issue users face:

```
2023-04-21 03:17:24,669 - [INFO]: Starting Tauticord...
2023-04-21 03:17:24,669 - [CRITICAL]: Fatal error occurred. Shutting down: 'NoneType' object has no attribute 'endswith'
```

Due to `base_url` being empty (not parsed correctly). Redirect error to a more human-understandable error message.
