### PR TITLE
[feat] Add memory percentage

### DIFF
--- a/modules/discord_connector.py
+++ b/modules/discord_connector.py
@@ -8,7 +8,7 @@ import modules.logs as logging
 import modules.statics as statics
 import modules.system_stats as system_stats
 import modules.tautulli_connector
-from modules import emojis
+from modules import emojis, utils
 from modules.emojis import EmojiManager
 from modules.settings_transports import LibraryVoiceChannelsVisibilities
 from modules.tautulli_connector import TautulliConnector, TautulliDataResponse
@@ -616,14 +616,14 @@ class DiscordConnector:
     async def update_performance_voice_channels(self) -> None:
         logging.info("Updating performance stats...")
         if self.performance_monitoring.get(statics.KEY_PERFORMANCE_MONITOR_CPU, False):
-            cpu_percent = "{:0.1f}%".format(system_stats.cpu_usage())
+            cpu_percent = f"{utils.format_number(system_stats.cpu_usage())}%"
             logging.info(f"Updating CPU voice channel with new CPU percent: {cpu_percent}")
             await self.edit_stat_voice_channel(channel_name="CPU",
                                                stat=cpu_percent,
                                                category=self.performance_voice_category)
 
         if self.performance_monitoring.get(statics.KEY_PERFORMANCE_MONITOR_MEMORY, False):
-            memory_percent = "{:0.1f} GB ({:0.1f}%)".format(system_stats.ram_usage(), system_stats.ram_usage_percentage())
+            memory_percent = f"{utils.format_number(system_stats.ram_usage())} GB ({utils.format_number(system_stats.ram_usage_percentage())}%)"
             logging.info(f"Updating Memory voice channel with new Memory percent: {memory_percent}")
             await self.edit_stat_voice_channel(channel_name="Memory",
                                                stat=memory_percent,

--- a/modules/discord_connector.py
+++ b/modules/discord_connector.py
@@ -580,7 +580,7 @@ class DiscordConnector:
             if self.voice_channel_settings.get(statics.KEY_LAN_BANDWIDTH, False):
                 bandwidth = activity.lan_bandwidth
                 logging.info(f"Updating Local Bandwidth voice channel with new bandwidth: {bandwidth}")
-                await self.edit_stat_voice_channel(channel_name="Local Bandwidth",
+                await self.edit_stat_voice_channel(channel_name="Local BW",
                                                    channel_id=self.voice_channel_settings.get(
                                                        statics.KEY_LAN_BANDWIDTH_CHANNEL_ID, 0),
                                                    stat=bandwidth,
@@ -588,7 +588,7 @@ class DiscordConnector:
             if self.voice_channel_settings.get(statics.KEY_REMOTE_BANDWIDTH, False):
                 bandwidth = activity.wan_bandwidth
                 logging.info(f"Updating Remote Bandwidth voice channel with new bandwidth: {bandwidth}")
-                await self.edit_stat_voice_channel(channel_name="Remote Bandwidth",
+                await self.edit_stat_voice_channel(channel_name="Remote BW",
                                                    channel_id=self.voice_channel_settings.get(
                                                        statics.KEY_REMOTE_BANDWIDTH_CHANNEL_ID, 0),
                                                    stat=bandwidth,
@@ -616,14 +616,14 @@ class DiscordConnector:
     async def update_performance_voice_channels(self) -> None:
         logging.info("Updating performance stats...")
         if self.performance_monitoring.get(statics.KEY_PERFORMANCE_MONITOR_CPU, False):
-            cpu_percent = "{:0.2f}%".format(system_stats.cpu_usage())
+            cpu_percent = "{:0.1f}%".format(system_stats.cpu_usage())
             logging.info(f"Updating CPU voice channel with new CPU percent: {cpu_percent}")
             await self.edit_stat_voice_channel(channel_name="CPU",
                                                stat=cpu_percent,
                                                category=self.performance_voice_category)
 
         if self.performance_monitoring.get(statics.KEY_PERFORMANCE_MONITOR_MEMORY, False):
-            memory_percent = "{:0.2f} GB".format(system_stats.ram_usage())
+            memory_percent = "{:0.1f} GB ({:0.1f}%)".format(system_stats.ram_usage(), system_stats.ram_usage_percentage())
             logging.info(f"Updating Memory voice channel with new Memory percent: {memory_percent}")
             await self.edit_stat_voice_channel(channel_name="Memory",
                                                stat=memory_percent,

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -11,15 +11,13 @@ def make_plural(word, count: int, suffix_override: str = 's') -> str:
 def quote(string: str) -> str:
     return f"\"{string}\""
 
-
-def _human_bitrate(number, denominator: int = 1, letter: str = "", d: int = 1) -> str:
-    if d <= 0:
-        return f'{int(number / denominator):d} {letter}bps'
+def format_number(number: float, denominator: int = 1, decimal_places: int = 1) -> str:
+    if decimal_places <= 0:
+        return f'{int(number / denominator):d}'
     else:
-        return f'{float(number / denominator):.{d}f} {letter}bps'
+        return f'{float(number / denominator):.{decimal_places}f}'
 
-
-def human_bitrate(_bytes, d: int = 1) -> str:
+def human_bitrate(_bytes, decimal_places: int = 1) -> str:
     # Return the given bitrate as a human friendly bps, Kbps, Mbps, Gbps, or Tbps string
 
     KB = float(1024)
@@ -44,7 +42,8 @@ def human_bitrate(_bytes, d: int = 1) -> str:
         denominator = TB
         letter = "T"
 
-    return _human_bitrate(_bytes, denominator=denominator, letter=letter, d=d)
+    value = format_number(number=_bytes, denominator=denominator, decimal_places=decimal_places)
+    return f"{value} {letter}bps"
 
 
 def milliseconds_to_minutes_seconds(milliseconds: int) -> str:


### PR DESCRIPTION
- Memory performance voice channel now displays percentage as well as usage
- **BREAKING**: `Remote Bandwidth` and `Local Bandwidth` channels renamed `Remote BW` and `Local BW` respectively to save space.
  - Will cause the channels to be remade, users will have to delete the old channels
- Percentages now displayed with 1 decimal place rather than 2 to save space.