### PR TITLE
[fix] Fix stream number emoji determination when using custom emojis

### DIFF
--- a/modules/discord_connector.py
+++ b/modules/discord_connector.py
@@ -373,8 +373,7 @@ class DiscordConnector:
 
     async def stop_tautulli_stream_via_reaction_emoji(self, emoji: discord.PartialEmoji, message: discord.Message) -> \
             discord.Message:
-        # remember to shift by 1 to convert index to human-readable
-        stream_number = self.emoji_manager.stream_number_from_emoji(emoji=emoji)
+        stream_number: int = self.emoji_manager.stream_number_from_emoji(emoji=emoji)
 
         logging.debug(f"Stopping stream {emoji}...")
         stopped_message = self.tautulli.stop_stream(emoji=emoji, stream_number=stream_number)

--- a/modules/emojis.py
+++ b/modules/emojis.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Union, List
 
 import discord
-from discord import Emoji
+from discord import Emoji, PartialEmoji
 
 from modules import statics
 
@@ -107,10 +107,15 @@ class EmojiManager:
             number_emojis.append(self.emoji_from_stream_number(i))
         return number_emojis
 
-    def stream_number_from_emoji(self, emoji) -> Union[int, None]:
+    def stream_number_from_emoji(self, emoji: PartialEmoji) -> Union[int, None]:
+        # If using the Tauticord custom emojis, name corresponds to the stream number (e.g. tc_1 is 1, tc_2 is 2, etc.)
+        if emoji.name.startswith(self._emoji_prefix):
+            number = emoji.name.replace(f"{self._emoji_prefix}_", "")
+            return int(number)
+        # Not using the Tauticord custom emojis, so we need to check the emoji itself
         for i, e in enumerate(self._emojis):
             if e == str(emoji):
-                return i + 1
+                return i + 1  # emoji 1 at index 0, etc.
         return None
 
     def emoji_from_stream_number(self, number: int) -> str:

--- a/modules/tautulli_connector.py
+++ b/modules/tautulli_connector.py
@@ -310,7 +310,7 @@ class TautulliConnector:
                                     error_occurred=True,
                                     server_name=self.server_name), 0, None, False  # If Tautulli is offline, assume Plex is offline
 
-    def stop_stream(self, emoji, stream_number) -> str:
+    def stop_stream(self, emoji, stream_number: int) -> str:
         """
         Stop a Plex stream
         :param emoji: Emoji used to stop the stream
@@ -318,7 +318,7 @@ class TautulliConnector:
         :return: Success/failure message
         """
         if stream_number not in session_ids.keys():
-            return utils.bold("Invalid stream number.")
+            return utils.bold(f"Invalid stream number: {stream_number}. Valid stream numbers: {', '.join([str(x) for x in session_ids.keys()])}")
         logging.info(f"User attempting to stop session {emoji}, id {session_ids[stream_number]}")
         try:
             if self.api.terminate_session(session_id=session_ids[stream_number], message=self.terminate_message):

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ from consts import (
 )
 from modules.analytics import GoogleAnalytics
 from modules.config_parser import Config
-from modules.statics import VERSION, COPYRIGHT, splash_logo
+from modules.statics import splash_logo
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="Tauticord - Discord bot for Tautulli")


### PR DESCRIPTION
Bot was not considering the custom styled numerical emojis when determining stream number.

Closes #123 