### PR TITLE
[fix] Fix stream number emoji determination when using custom emojis (again)

### DIFF
--- a/modules/emojis.py
+++ b/modules/emojis.py
@@ -113,9 +113,9 @@ class EmojiManager:
             number = emoji.name.replace(f"{self._emoji_prefix}_", "")
             return int(number)
         # Not using the Tauticord custom emojis, so we need to check the emoji itself
-        for i, e in enumerate(self._emojis):
+        for num, e in self._emojis.items():
             if e == str(emoji):
-                return i + 1  # emoji 1 at index 0, etc.
+                return int(num)
         return None
 
     def emoji_from_stream_number(self, number: int) -> str:


### PR DESCRIPTION
Move from index calculation to key-value pair comparison. Casting a string to an integer is janky, but only just as janky as determining the index + 1

Closes #123 