### PR TITLE
[bug] Limit content title length in summary embed

### DIFF
--- a/modules/statics.py
+++ b/modules/statics.py
@@ -17,6 +17,8 @@ voice_channel_order = {
     'remoteBandwidth': 5
 }
 
+MAX_EMBED_FIELD_NAME_LENGTH = 200 # 256 - estimated emojis + flairs + safety margin
+
 
 KEY_STATS_CATEGORY_NAME = "stats_category_name"
 KEY_COUNT = "count"

--- a/modules/text_manager.py
+++ b/modules/text_manager.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Union
 from modules import statics, utils
 from modules.emojis import EmojiManager
 from modules.time_manager import TimeManager
+from modules.utils import limit_text_length
 
 
 class TextManager:
@@ -87,6 +88,7 @@ class TextManager:
         icon = session.get_status_icon(emoji_manager=emoji_manager)
         media_type_icon = session.get_type_icon(emoji_manager=emoji_manager)
         title = session.title
+        title = limit_text_length(text=title, limit=statics.MAX_EMBED_FIELD_NAME_LENGTH)
         return f"""{emoji} | {icon} {media_type_icon} *{title}*"""
 
     def session_body(self, session, emoji_manager: EmojiManager) -> str:

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -76,6 +76,13 @@ def now_plus_milliseconds(milliseconds: int, timezone_code: str = None) -> datet
         now = datetime.now()
     return now + timedelta(milliseconds=milliseconds)
 
+def limit_text_length(text: str, limit: int, suffix: str = "...") -> str:
+    if len(text) <= limit:
+        return text
+
+    suffix_length = len(suffix)
+    return f"{text[:limit - suffix_length]}{suffix}"
+
 
 def string_to_datetime(date_string: str, template: str = "%Y-%m-%dT%H:%M:%S") -> datetime:
     """


### PR DESCRIPTION
Discord throws an exception if the text in the name of any embed field exceeds 256 characters. Patch limits the "name" (content title + emojis) to under 256 characters, using `...` as suffix if title exceeds length.