### PR TITLE
[chore] Add 5 MB log rotation + 5 backups

### DIFF
--- a/modules/logs.py
+++ b/modules/logs.py
@@ -1,4 +1,6 @@
 import logging
+import os
+from logging.handlers import RotatingFileHandler
 from typing import Optional
 
 _nameToLevel = {
@@ -13,7 +15,8 @@ _nameToLevel = {
 }
 
 _DEFAULT_LOGGER_NAME = None
-
+MAX_SIZE = 5000000 # 5 MB
+MAX_FILES = 5
 
 def init(app_name: str,
          console_log_level: str,
@@ -39,7 +42,12 @@ def init(app_name: str,
     # File logging
     if log_to_file:
         log_file_dir = log_file_dir if log_file_dir.endswith('/') else f'{log_file_dir}/'
-        file_logger = logging.FileHandler(f'{log_file_dir}{app_name}.log')
+        try:
+            os.makedirs(log_file_dir)
+        except:
+            pass
+        file_logger = RotatingFileHandler(filename=f'{log_file_dir}{app_name}.log',
+                                          maxBytes=MAX_SIZE, backupCount=MAX_FILES, encoding='utf-8')
         file_logger.setFormatter(formatter)
         file_logger.setLevel(level_name_to_level(file_log_level or console_log_level))
         logger.addHandler(file_logger)

--- a/run.py
+++ b/run.py
@@ -29,8 +29,6 @@ Bot will use config, in order:
 3. Environmental variables
 """
 parser.add_argument("-c", "--config", help="Path to config file", default=DEFAULT_CONFIG_PATH)
-
-# Should include trailing backslash
 parser.add_argument("-l", "--log", help="Log file directory", default=DEFAULT_LOG_DIR)
 
 args = parser.parse_args()


### PR DESCRIPTION
Seeing as I ran out of space on my VPS today because Tauticord's logs had reached 2.9 GB, this is long overdue.

Max log file size is 5 MB (should be good for several iterations), with 5 additional rolling logs, for a total of 6 * 5 = 30 MB of logs maximum.

Closes #139 