### PR TITLE
[feat] Improve Docker base, PM2, auto-restart settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ cython_debug/
 config.yaml
 /docker-compose_test.yml
 /scratch.py
+/on_host/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM keymetrics/pm2:18-alpine
+FROM python:3.10-alpine3.18
 WORKDIR /app
 
-# Install Python and other utilities
-RUN apk add --no-cache --update alpine-sdk git wget python3 python3-dev ca-certificates musl-dev libc-dev gcc bash nano linux-headers && \
+# Install Python utilities
+RUN apk add --no-cache --update alpine-sdk wget ca-certificates musl-dev libc-dev gcc bash linux-headers && \
     python3 -m ensurepip && \
     pip3 install --no-cache-dir --upgrade pip setuptools
 
-# Install pm2-logrotate
-RUN pm2 install pm2-logrotate
+# Install Node.js
+RUN apk add --update npm
+
+# Install pm2
+RUN npm install pm2 -g
 
 # Copy requirements.txt from build machine to WORKDIR (/app) folder (important we do this BEFORE copying the rest of the files to avoid re-running pip install on every code change)
 COPY requirements.txt requirements.txt
@@ -33,4 +36,4 @@ RUN echo "**** removing unneeded files ****"
 RUN rm -rf /app/requirements.txt
 
 # Run the app
-CMD [ "pm2-runtime", "start", "ecosystem.config.json" ]
+CMD [ "pm2-runtime", "start", "ecosystem.config.json"]

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -9,13 +9,17 @@
       "instances": 1
     },
     {
-      "name": "monitor",
+      "name": "tauticord",
       "interpreter": "python",
       "script": "run.py",
       "autorestart": true,
-      "watch": false,
+      // Auto restart on config change
+      "watch": ["/config"],
+      "watch_delay": 1000,
       "exec_mode": "fork",
-      "instances": 1
+      "instances": 1,
+      // 101 - Discord login failed
+      "stop_exit_codes": [101]
     }
   ]
 }

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -1,0 +1,14 @@
+import discord
+
+
+def determine_exit_code(exception: Exception) -> int:
+    """
+    Determine the exit code based on the exception that was thrown
+
+    :param exception: The exception that was thrown
+    :return: The exit code
+    """
+    if isinstance(exception, discord.LoginFailure):
+        return 101  # Invalid Discord token
+    else:
+        return 1

--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@ from consts import (
 from modules.analytics import GoogleAnalytics
 from modules.config_parser import Config
 from modules.statics import splash_logo
+from modules.errors import determine_exit_code
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="Tauticord - Discord bot for Tautulli")
@@ -83,4 +84,6 @@ if __name__ == '__main__':
         discord_connector.connect()
     except Exception as e:
         logging.fatal(f"Fatal error occurred. Shutting down: {e}")
-        exit(1)  # Exit the script if an error bubbles up (like an internet connection error)
+        exit_code = determine_exit_code(exception=e)
+        logging.fatal(f"Exiting with code {exit_code}")
+        exit(exit_code)  # Exit the script if an error bubbles up (like an internet connection error)


### PR DESCRIPTION
#### Docker
- Improve base image used for Docker container (lock to Python 3.10)

#### PM2
- Install latest PM2 in container (previous base image was 2+ years out of date and missing features)
  - Remove unused pm2-logrotate
- Improve PM2 process
  - Name `tauticord` process properly
  - Auto-restart the bot if the config file changes
  - Cancel auto-restart based on process exit status code

#### Tauticord
- Parse bot-killing exception to determine proper exit code
  - Throw code 101 (avoid constant restart) if exception due to invalid Discord token