### PR TITLE
[fix] Ignore logs for PM2 restart strategy

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -15,6 +15,8 @@
       "autorestart": true,
       // Auto restart on config change
       "watch": ["/config"],
+      // Ignore specific folders
+      "ignore_watch": ["logs", "/config/logs"],
       "watch_delay": 1000,
       "exec_mode": "fork",
       "instances": 1,


### PR DESCRIPTION
Ignore logs in PM2 watcha strategy, in case users accidentally put the logs directory in the config directory.