### PR TITLE
[chore] Only auto-restart bot if specifically the config file has changed

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -14,9 +14,7 @@
       "script": "run.py",
       "autorestart": true,
       // Auto restart on config change
-      "watch": ["/config"],
-      // Ignore specific folders
-      "ignore_watch": ["logs", "/config/logs"],
+      "watch": ["/config/config.yaml"],
       "watch_delay": 1000,
       "exec_mode": "fork",
       "instances": 1,


### PR DESCRIPTION
Some users seem to use the same mapped folder for both logs and config files, making "watch the `/config` folder for changes" the same as "watch the `/log` folder for changes", causing every log event to endlessly reboot the bot.

Rather than explicitly ignoring every single possible log file (the regex patterns promised by the PM2 documentation don't actually work, looking at the source code), we'll only specifically watch for changes to the `/config/config.yaml` file.