### PR TITLE
[Fix] User count display, slash commands setting

### DIFF
--- a/modules/discord/command_manager.py
+++ b/modules/discord/command_manager.py
@@ -50,19 +50,17 @@ class CommandManager:
         return str(interaction.user.id) in self._admin_ids
 
     async def register_slash_commands(self):
-        for cog in self._cogs_to_add:
-            await self._add_cog(cog)
+        if self._enable_slash_commands:
+            for cog in self._cogs_to_add:
+                await self._add_cog(cog)
+            logging.info("Slash commands registered.")
+        else:
+            logging.info("Slash commands not enabled. Skipping registration...")
 
-        logging.info("Slash commands registered.")
-
-    async def activate_slash_commands(self):
-        if not self._enable_slash_commands:
-            logging.info("Slash commands not enabled. Skipping activation.")
-            return
-
+        # Need to sync regardless (either adding newly-registered cogs or syncing/removing existing ones)
         if not self._synced:
             await self._bot.tree.sync(guild=self._guild)
             self._synced = True
-            logging.info("Slash commands activated.")
+            logging.info("Slash commands synced.")
         else:
-            logging.info("Slash commands already activated.")
+            logging.info("Slash commands already synced.")

--- a/modules/discord/discord_connector.py
+++ b/modules/discord/discord_connector.py
@@ -299,9 +299,6 @@ class DiscordConnector:
         logging.info('Setting up Discord slash commands...')
         await self.command_manager.register_slash_commands()
 
-        logging.info("Activating Discord slash commands...")
-        await self.command_manager.activate_slash_commands()
-
         logging.info("Setting bot status...")
         await self.client.change_presence(
             activity=discord.Activity(type=discord.ActivityType.watching, name='for Tautulli stats'))

--- a/modules/settings/config_parser.py
+++ b/modules/settings/config_parser.py
@@ -475,6 +475,7 @@ class ExtrasConfig(ConfigSection):
     def _performance(self) -> ConfigSection:
         return self._get_subsection(key="Performance")
 
+    @property
     def _performance_monitor_tautulli_user_count(self) -> bool:
         value = self._performance._get_value(key="TautulliUserCount", default=False,
                                              env_name_override="TC_MONITOR_TAUTULLI_USER_COUNT")


### PR DESCRIPTION
- Fix Tautulli User Count channel not being updated, due to issue with parsing setting (closes #170)
- Fix slash commands not being enabled/disabled according to setting, due to missing sync