### PR TITLE
[feat] Add ability to override name for any voice channel

### DIFF
--- a/.schema/config_v2.schema.json
+++ b/.schema/config_v2.schema.json
@@ -92,6 +92,17 @@
       "id": "#/definitions/voiceChannel",
       "type": "object",
       "properties": {
+        "CustomName": {
+          "description": "The custom name to use for the voice channel (overrides the default name)",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/discordVoiceChannelName"
+            },
+            {
+              "$ref": "#/definitions/emptyString"
+            }
+          ]
+        },
         "CustomEmoji": {
           "description": "The custom emoji to use for the voice channel (overrides the default emoji)",
           "type": "string"

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -104,6 +104,7 @@ Tauticord currently offers three different types of statistics to display in voi
 All statistic voice channels have the following customization options:
 
 - Enable/Disable the voice channel (if disabled, Tauticord will not create/update the channel)
+- Custom name (overrides the default name for the statistic)
 - Custom emoji (overrides the default emoji for the statistic)
 - Voice channel ID specification (rather than letting Tauticord auto-generate the channel)
 
@@ -150,6 +151,7 @@ Libraries:
   - Name: Audiobooks  # The name of the library in Plex
     AlternateName: My Audiobooks  # The name to display in the statistics voice channels
     Albums: # Settings for the "Albums" statistic
+      CustomName: 'Books'  # Custom name to use for the statistic
       CustomEmoji: '📻'  # Custom emoji to use for the statistic
       Enable: true
       VoiceChannelID: 0  # The ID of the voice channel to update (0 for auto-management)

--- a/migrations/m002_old_config_to_new_config.py
+++ b/migrations/m002_old_config_to_new_config.py
@@ -45,10 +45,11 @@ class ConfigWriter:
             value = default
         self.add(value=value, key_path=to_path)
 
-    def build_voice_channel_config(self, enabled: bool, custom_emoji: str = "",
+    def build_voice_channel_config(self, enabled: bool, custom_name: str = "", custom_emoji: str = "",
                                    voice_channel_id: int = 0, additional_pairs: dict = None) -> dict:
         config = {
             "Enable": enabled,
+            "CustomName": custom_name,
             "CustomEmoji": custom_emoji,
             "VoiceChannelID": voice_channel_id
         }

--- a/modules/settings/config_parser.py
+++ b/modules/settings/config_parser.py
@@ -38,6 +38,10 @@ class VoiceChannelConfig(ConfigSection):
 
     def to_model(self) -> settings_models.VoiceChannel:
         enable: bool = utils.extract_boolean(self.get_value(key="Enable", default=False))
+        name: str = self.get_value(key="CustomName", default="")
+        if not name:
+            # Fall back to the default channel name if a custom name is not provided
+            name: str = self.channel_name
         emoji: str = self.get_value(key="CustomEmoji", default="")
         if not emoji:
             # Fall back to the default emoji if a custom emoji is not provided
@@ -45,7 +49,7 @@ class VoiceChannelConfig(ConfigSection):
         channel_id: int = self.get_value(key="VoiceChannelID", default="0")
 
         return settings_models.VoiceChannel(
-            name=self.channel_name,
+            name=name.strip(),
             enable=enable,
             emoji=emoji.strip(),
             channel_id=channel_id

--- a/tauticord.yaml.example
+++ b/tauticord.yaml.example
@@ -81,6 +81,8 @@ Stats:
     StatTypes:
       # Bandwidth settings
       Bandwidth:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable bandwidth stats
@@ -89,6 +91,8 @@ Stats:
         VoiceChannelID: 0
       # Local bandwidth settings
       LocalBandwidth:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable local bandwidth stats
@@ -97,6 +101,8 @@ Stats:
         VoiceChannelID: 0
       # Plex server availability settings
       PlexServerAvailability:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable Plex server availability stats
@@ -105,6 +111,8 @@ Stats:
         VoiceChannelID: 0
       # Remote bandwidth settings
       RemoteBandwidth:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable remote bandwidth stats
@@ -113,6 +121,8 @@ Stats:
         VoiceChannelID: 0
       # Stream count settings
       StreamCount:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable stream count stats
@@ -121,6 +131,8 @@ Stats:
         VoiceChannelID: 0
       # Transcode count settings
       TranscodeCount:
+        # The custom name
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable transcode count stats
@@ -144,6 +156,8 @@ Stats:
         # How to display stats for each type of media in this library
         # Only relevant stats will be included based on library type (e.g. a TV Show library will ignore Album settings)
         Albums:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -151,6 +165,8 @@ Stats:
           # Use a specific voice channel for this library's stats, rather than generating a new one
           VoiceChannelID: 0
         Artists:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -158,6 +174,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Episodes:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -165,6 +183,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Movies:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -172,6 +192,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Series:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -179,6 +201,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Tracks:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -192,6 +216,8 @@ Stats:
         # How to display stats for each type of media in this library
         # Only relevant stats will be included based on library type (e.g. a TV Show library will ignore Album settings)
         Albums:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -199,6 +225,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Artists:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -206,6 +234,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Episodes:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -213,6 +243,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Movies:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -220,6 +252,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Series:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -227,6 +261,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Tracks:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -240,6 +276,8 @@ Stats:
         # How to display stats for each type of media in this library
         # Only relevant stats will be included based on library type (e.g. a TV Show library will ignore Album settings)
         Albums:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -247,6 +285,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Artists:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -254,6 +294,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Episodes:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -261,6 +303,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Movies:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -268,6 +312,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Series:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -275,6 +321,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Tracks:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -293,6 +341,8 @@ Stats:
         # How to display stats for each type of media in this library
         # Only relevant stats will be included based on library type (e.g. a TV Show library will ignore Album settings)
         Albums:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -300,6 +350,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Artists:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -307,6 +359,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Episodes:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -314,6 +368,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Movies:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -321,6 +377,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Series:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -328,6 +386,8 @@ Stats:
           # The ID of the voice channel
           VoiceChannelID: 0
         Tracks:
+          # The custom name for this metric
+          CustomName: ''
           # The custom emoji for this metric
           CustomEmoji: ''
           # Whether to display this metric for this library
@@ -344,6 +404,8 @@ Stats:
     Metrics:
       # CPU settings
       CPU:
+        # The custom name for this metric
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable CPU stats
@@ -352,6 +414,8 @@ Stats:
         VoiceChannelID: 0
       # Disk space settings
       DiskSpace:
+        # The custom name for this metric
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable disk space stats
@@ -360,6 +424,8 @@ Stats:
         VoiceChannelID: 0
       # Memory settings
       Memory:
+        # The custom name for this metric
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable memory stats
@@ -368,6 +434,8 @@ Stats:
         VoiceChannelID: 0
       # User count settings
       UserCount:
+        # The custom name for this metric
+        CustomName: ''
         # The custom emoji
         CustomEmoji: ''
         # Whether to enable user count stats


### PR DESCRIPTION
User can override the default channel name for any voice channel (not recommended for library stat channels)