### PR TITLE
[fix] Channel type default causing Discord channels to not be created

### DIFF
--- a/modules/discord/command_manager.py
+++ b/modules/discord/command_manager.py
@@ -31,7 +31,8 @@ class CommandManager:
     def _cogs_to_add(self):
         return [
             Most(bot=self._bot, tautulli=self._tautulli, admin_check=self.is_admin),
-            Summary(bot=self._bot, tautulli=self._tautulli, emoji_manager=self._emoji_manager, admin_check=self.is_admin),
+            Summary(bot=self._bot, tautulli=self._tautulli, emoji_manager=self._emoji_manager,
+                    admin_check=self.is_admin),
             Recently(bot=self._bot, tautulli=self._tautulli, admin_check=self.is_admin),
         ]
 
@@ -58,6 +59,7 @@ class CommandManager:
             logging.info("Slash commands not enabled. Skipping registration...")
 
         # Need to sync regardless (either adding newly-registered cogs or syncing/removing existing ones)
+        logging.info("Syncing slash commands...")
         if not self._synced:
             await self._bot.tree.sync(guild=self._guild)
             self._synced = True

--- a/modules/discord/discord_connector.py
+++ b/modules/discord/discord_connector.py
@@ -119,7 +119,8 @@ class DiscordConnector:
                 await discord_utils.get_or_create_discord_channel_by_name(
                     client=self.client,
                     guild_id=self.guild_id,
-                    channel_name=self.tautulli_summary_channel_name)
+                    channel_name=self.tautulli_summary_channel_name,
+                    channel_type=discord.ChannelType.text)
             if not self.tautulli_summary_channel:
                 raise Exception(f"Could not load {quote(self.tautulli_summary_channel_name)} channel. Exiting...")
 

--- a/modules/discord/discord_utils.py
+++ b/modules/discord/discord_utils.py
@@ -50,7 +50,7 @@ async def create_discord_category(client: discord.Client,
 async def create_discord_channel(client: discord.Client,
                                  guild_id: int,
                                  channel_name: str,
-                                 channel_type: discord.ChannelType = discord.ChannelType.text,
+                                 channel_type: discord.ChannelType,
                                  category: discord.CategoryChannel = None) -> \
         Union[discord.TextChannel, discord.VoiceChannel, discord.CategoryChannel]:
     match channel_type:
@@ -94,7 +94,7 @@ async def get_all_discord_channels(client: discord.Client,
 async def get_or_create_discord_channel_by_name(client: discord.Client,
                                                 guild_id: int,
                                                 channel_name: str,
-                                                channel_type: discord.ChannelType = None,
+                                                channel_type: discord.ChannelType,
                                                 category: discord.CategoryChannel = None) -> \
         Union[discord.VoiceChannel, discord.TextChannel, discord.CategoryChannel, None]:
     channels = await get_all_discord_channels(client=client, guild_id=guild_id, channel_type=channel_type)
@@ -115,7 +115,7 @@ async def get_or_create_discord_channel_by_name(client: discord.Client,
 async def get_or_create_discord_channel_by_starting_name(client: discord.Client,
                                                          guild_id: int,
                                                          starting_channel_name: str,
-                                                         channel_type: discord.ChannelType = None,
+                                                         channel_type: discord.ChannelType,
                                                          category: discord.CategoryChannel = None) -> \
         Union[discord.VoiceChannel, discord.TextChannel, None]:
     channels = await get_all_discord_channels(client=client, guild_id=guild_id, channel_type=channel_type)


### PR DESCRIPTION
- Remove default channel type for Discord causing creation errors in switch-case (closes #201 )
- Improve logs for slash command syncing