### PR TITLE
[feat] Option to customize bot's Discord activity status

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ Dockerfile
 .idea
 docker-compose.yml
 venv
+.venv
 __pycache__
 Tauticord.log
 documentation

--- a/.schema/config_v2.schema.json
+++ b/.schema/config_v2.schema.json
@@ -322,6 +322,28 @@
           "title": "Enable slash commands",
           "description": "Whether to enable slash commands for the bot",
           "type": "boolean"
+        },
+        "StatusMessage": {
+          "title": "Bot Discord activity status",
+          "description": "Settings regarding the bot's Discord status/activity",
+          "type": "object",
+          "properties": {
+            "Enable": {
+              "title": "Enable bot activity status",
+              "description": "Whether to enable the bot's activity status",
+              "type": "boolean"
+            },
+            "CustomMessage": {
+              "title": "Custom activity status message",
+              "description": "Display a custom activity status message. Overrides default if not-empty",
+              "$ref": "#/definitions/emptyableString"
+            },
+            "ShowStreamCount": {
+              "title": "Show active stream count",
+              "description": "Whether to display current active stream count in activity status message",
+              "type": "boolean"
+            }
+          }
         }
       },
       "required": [

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-BIN = .venv/bin
+UNIX_BIN = .venv/bin
+WINDOWS_BIN = .venv\Scripts
 
-install:
-	${BIN}/pip install -r requirements.txt
+install-unix:
+	${UNIX_BIN}/pip install -r requirements.txt
+
+install-win:
+	${WINDOWS_BIN}\pip.exe install -r .\requirements.txt

--- a/migrations/m002_old_config_to_new_config.py
+++ b/migrations/m002_old_config_to_new_config.py
@@ -123,8 +123,10 @@ class Migration(BaseMigration):
         new_config.migrate_value(value=old_config.tautulli.api_key, to_path=["Tautulli", "APIKey"], default="")
         new_config.migrate_value(value=old_config.tautulli.disable_ssl_verification,
                                  to_path=["Tautulli", "UseSelfSignedCert"], default=False)
-        new_config.migrate_value(value=old_config.tautulli.refresh_interval, to_path=["Tautulli", "RefreshSeconds"], default=15)
-        new_config.migrate_value(value=old_config.tautulli.terminate_message, to_path=["Tautulli", "TerminateMessage"], default="")
+        new_config.migrate_value(value=old_config.tautulli.refresh_interval, to_path=["Tautulli", "RefreshSeconds"],
+                                 default=15)
+        new_config.migrate_value(value=old_config.tautulli.terminate_message, to_path=["Tautulli", "TerminateMessage"],
+                                 default="")
         # Plex Pass setting no longer used
 
         # Discord
@@ -136,10 +138,18 @@ class Migration(BaseMigration):
         new_config.migrate_value(value=old_config.discord.channel_name, to_path=["Discord", "ChannelName"])
         new_config.migrate_value(value=old_config.discord.enable_slash_commands,
                                  to_path=["Discord", "EnableSlashCommands"], default=False)
+        status_message_settings = {
+            "Enable": True,
+            "CustomMessage": "",
+            "ShowStreamCount": True,
+        }
+        new_config.add(value=status_message_settings, key_path=["Discord", "StatusMessage"])
 
         # Display
-        new_config.migrate_value(value=old_config.tautulli.server_name, to_path=["Display", "ServerName"], default="Plex Server")
-        new_config.migrate_value(value=old_config.tautulli._use_friendly_names, to_path=["Display", "UseFriendlyNames"], default=False)
+        new_config.migrate_value(value=old_config.tautulli.server_name, to_path=["Display", "ServerName"],
+                                 default="Plex Server")
+        new_config.migrate_value(value=old_config.tautulli._use_friendly_names, to_path=["Display", "UseFriendlyNames"],
+                                 default=False)
         new_config.migrate_value(value=old_config.tautulli.thousands_separator,
                                  to_path=["Display", "ThousandsSeparator"], default="")
         new_config.migrate_value(value=old_config.tautulli._anonymize_hide_usernames,
@@ -261,7 +271,8 @@ class Migration(BaseMigration):
             new_config.add(value=channel_config, key_path=["Stats", "Performance", "Metrics", channel_type])
 
         # Extras
-        new_config.migrate_value(value=old_config.extras.allow_analytics, to_path=["Extras", "AllowAnalytics"], default=True)
+        new_config.migrate_value(value=old_config.extras.allow_analytics, to_path=["Extras", "AllowAnalytics"],
+                                 default=True)
         new_config.add(value=True, key_path=["Extras", "EnableUpdateReminders"])
 
         # Write config file to disk

--- a/modules/discord/discord_utils.py
+++ b/modules/discord/discord_utils.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Optional
 
 import discord
 
@@ -174,6 +174,43 @@ async def send_embed_message(embed: discord.Embed = None, message: discord.Messa
             return await channel.send(content="Something went wrong.")
         else:
             return await channel.send(content=None, embed=embed)
+
+
+async def update_presence(client: discord.Client,
+                          line_one: str,
+                          activity_name: Optional[str] = None,
+                          large_image: Optional[str] = None,
+                          large_image_text: Optional[str] = None,
+                          small_image: Optional[str] = None,
+                          small_image_text: Optional[str] = None,
+                          status: Optional[discord.Status] = discord.Status.online):
+    # ref: https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields
+    # ref: https://discord.com/developers/docs/game-sdk/activities#updateactivity
+    use_custom_activity_type = activity_name is None
+    if use_custom_activity_type:
+        activity_type = discord.ActivityType.custom
+        name = line_one
+        details = None
+        state = None
+    else:
+        activity_type = discord.ActivityType.watching
+        name = activity_name
+        details = None
+        state = line_one
+
+    activity = discord.Activity(
+        name=name,
+        type=activity_type,
+        details=details,
+        state=state,
+        assets={
+            'large_image': large_image,
+            'large_text': large_image_text,
+            'small_image': small_image,
+            'small_text': small_image_text
+        }
+    )
+    await client.change_presence(activity=activity, status=status)
 
 
 def is_valid_reaction(reaction_emoji: discord.PartialEmoji,

--- a/modules/settings/models/__init__.py
+++ b/modules/settings/models/__init__.py
@@ -1,5 +1,5 @@
 from modules.settings.models.anonymity import Anonymity
-from modules.settings.models.discord import Discord
+from modules.settings.models.discord import Discord, StatusMessage as DiscordStatusMessage
 from modules.settings.models.display import Display
 from modules.settings.models.extras import Extras
 from modules.settings.models.libraries import BaseLibrary, Library, CombinedLibrary

--- a/modules/settings/models/discord.py
+++ b/modules/settings/models/discord.py
@@ -1,5 +1,42 @@
+from typing import Optional
+
 from modules.settings.models.base import BaseConfig
 from modules.utils import mark_exists
+
+
+class StatusMessage(BaseConfig):
+    enable: bool
+    activity_name: Optional[str]
+    custom_message: Optional[str]
+    show_stream_count: bool
+
+    @property
+    def should_update_on_startup(self) -> bool:
+        return self.enable
+
+    @property
+    def should_update_with_activity(self) -> bool:
+        return self.enable
+
+    def message(self, stream_count: int, fallback: Optional[str] = None) -> str:
+        if self.custom_message:
+            return self.custom_message
+
+        if fallback:
+            return fallback
+
+        if self.show_stream_count:
+            return f"Currently {stream_count} stream{'s' if stream_count != 1 else ''} active"
+        else:
+            return "https://github.com/nwithan8/tauticord"
+
+    def as_dict(self) -> dict:
+        return {
+            "enable": self.enable,
+            "activity_name": self.activity_name,
+            "custom_message": self.custom_message,
+            "show_stream_count": self.show_stream_count
+        }
 
 
 class Discord(BaseConfig):
@@ -9,6 +46,7 @@ class Discord(BaseConfig):
     enable_slash_commands: bool
     use_summary_message: bool
     server_id: int
+    status_message_settings: StatusMessage
 
     def as_dict(self) -> dict:
         return {
@@ -17,5 +55,6 @@ class Discord(BaseConfig):
             "channel_name": self.channel_name,
             "enable_slash_commands": self.enable_slash_commands,
             "use_summary_message": self.use_summary_message,
-            "server_id": self.server_id
+            "server_id": self.server_id,
+            "status_message_settings": self.status_message_settings.as_dict()
         }

--- a/modules/tasks/activity.py
+++ b/modules/tasks/activity.py
@@ -19,6 +19,7 @@ class ActivityStatsAndSummaryMessage(VoiceCategoryStatsMonitor):
                  tautulli_connector: TautulliConnector,
                  guild_id: int,
                  message: discord.Message,
+                 discord_status_settings: modules.settings.models.DiscordStatusMessage,
                  emoji_manager: EmojiManager,
                  version_checker: VersionChecker,
                  voice_category: discord.CategoryChannel = None):
@@ -28,6 +29,7 @@ class ActivityStatsAndSummaryMessage(VoiceCategoryStatsMonitor):
                          voice_category=voice_category)
         self.message = message
         self.stats_settings = settings
+        self.discord_status_settings = discord_status_settings
         self.tautulli = tautulli_connector
         self.emoji_manager = emoji_manager
         self.version_checker = version_checker
@@ -172,6 +174,13 @@ class ActivityStatsAndSummaryMessage(VoiceCategoryStatsMonitor):
 
         if self.stats_settings.enable:
             await self.update_activity_stats(summary=summary)
+
+        if self.discord_status_settings.should_update_with_activity:
+            activity_name = self.discord_status_settings.activity_name
+            message = self.discord_status_settings.message(stream_count=0)
+            await discord_utils.update_presence(client=self.discord_client,
+                                                activity_name=activity_name,
+                                                line_one=message)
 
         if self.message:  # Set in the constructor, indicates that a summary message should be sent
             await self.update_activity_summary_message(summary=summary)

--- a/modules/versioning.py
+++ b/modules/versioning.py
@@ -66,7 +66,7 @@ class VersionChecker:
         self.enable = enable
         self._new_version_available = False
 
-    async def check_for_new_version(self):
+    async def monitor_for_new_version(self):
         while True:
             try:
                 self._new_version_available = newer_version_available()


### PR DESCRIPTION
- Can customize bot's Discord activity status, or use default "Watching Tautulli stats" status (closes #203 )
- Option to display live stream count in activity status, or fallback to GitHub link
- Minor verbiage improvements