### PR TITLE
[fix] Custom status not being displayed

### DIFF
--- a/modules/discord/discord_utils.py
+++ b/modules/discord/discord_utils.py
@@ -189,9 +189,10 @@ async def update_presence(client: discord.Client,
     use_custom_activity_type = activity_name is None
     if use_custom_activity_type:
         activity_type = discord.ActivityType.custom
+        # For a custom message, all three fields need to be populated
         name = line_one
-        details = None
-        state = None
+        details = line_one
+        state = line_one
     else:
         activity_type = discord.ActivityType.watching
         name = activity_name


### PR DESCRIPTION
Discord really discourages users from using custom messages by making their parameters behave differently server-side for custom messages versus standard activity 😞 