### PR TITLE
[fix] Override voice channel check when determining if live activity cron should start

### DIFF
--- a/modules/discord/services/live_activity.py
+++ b/modules/discord/services/live_activity.py
@@ -121,7 +121,9 @@ class LiveActivityMonitor(BaseService):
                                                                version_checker=self.version_checker,
                                                                voice_category=activity_stats_voice_category)
         # noinspection PyAsyncCall
-        asyncio.create_task(self.activity_monitor.run_service(interval_seconds=refresh_time))
+        # Want the service to run even if the voice channel is not found (e.g. text summary only)
+        asyncio.create_task(self.activity_monitor.run_service(interval_seconds=refresh_time,
+                                                              override_voice_channel_check=True))
 
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         if not self.tautulli_summary_channel or not self.activity_monitor:

--- a/modules/tasks/voice_category_stats.py
+++ b/modules/tasks/voice_category_stats.py
@@ -23,8 +23,9 @@ class VoiceCategoryStatsMonitor:
         self.voice_category = voice_category
         self.service_entrypoint = service_entrypoint
 
-    async def run_service(self, interval_seconds: int) -> None:
-        if not self.voice_category:
+    async def run_service(self, interval_seconds: int, override_voice_channel_check: bool = False) -> None:
+        if not self.voice_category and not override_voice_channel_check:
+            logging.debug("No voice category set, skipping service run...")
             return  # No performance voice category set, so don't bother
 
         while True:


### PR DESCRIPTION
If voice channel stats are disabled, voice category was not collected, meaning regardless of whether text summary message was enabled/disabled, cron job to update live data was not running.