### PR TITLE
[feat] Add option to disable termination reaction options

### DIFF
--- a/.schema/config_v2.schema.json
+++ b/.schema/config_v2.schema.json
@@ -358,6 +358,11 @@
           "description": "The name of the channel where the bot will post messages",
           "$ref": "#/definitions/discordTextChannelName"
         },
+        "EnableTermination": {
+          "title": "Enable stream termination",
+          "description": "Whether to enable stream termination",
+          "type": "boolean"
+        },
         "EnableSlashCommands": {
           "title": "Enable slash commands",
           "description": "Whether to enable slash commands for the bot",

--- a/documentation/ANNOUNCEMENTS.md
+++ b/documentation/ANNOUNCEMENTS.md
@@ -4,11 +4,11 @@
 
 **Latest Release**: *v5.3.4*
 
-**Affected Release**: *v5.4.0+*
+**Affected Release**: *v5.x.0+*
 
 **Affected Users**: Those using Tauticord with Tautulli versions v2.12.x and v2.13.x
 
-The next minor release of Tauticord will drop support for Tautulli versions v2.12.x and v2.13.x. This is due to the
+An upcoming minor release of Tauticord will drop support for Tautulli versions v2.12.x and v2.13.x. This is due to the
 release of Tautulli v2.14.0, which introduced breaking changes to the API.
 
 Because Tauticord enforces strict compatibility checking with Tautulli, the underlying `tautulli` API library will need

--- a/migrations/m002_old_config_to_new_config.py
+++ b/migrations/m002_old_config_to_new_config.py
@@ -136,6 +136,7 @@ class Migration(BaseMigration):
         new_config.migrate_value(value=old_config.discord.use_summary_text_message,
                                  to_path=["Discord", "PostSummaryMessage"], default=True)
         new_config.migrate_value(value=old_config.discord.channel_name, to_path=["Discord", "ChannelName"])
+        new_config.add(value=True, key_path=["Discord", "EnableTermination"])
         new_config.migrate_value(value=old_config.discord.enable_slash_commands,
                                  to_path=["Discord", "EnableSlashCommands"], default=False)
         status_message_settings = {

--- a/modules/discord/commands/summary.py
+++ b/modules/discord/commands/summary.py
@@ -35,6 +35,6 @@ class Summary(commands.Cog):
         if not await self.check_admin(interaction):
             return
 
-        # Does NOT include new version reminder.
-        summary = self._tautulli.refresh_data(emoji_manager=self._emoji_manager)
+        # Does NOT include new version reminder or stream termination.
+        summary = self._tautulli.refresh_data(enable_stream_termination_if_possible=False, emoji_manager=self._emoji_manager)
         await interaction.response.send_message(embed=summary.embed, ephemeral=not share)

--- a/modules/discord/models/tautulli_activity_summary.py
+++ b/modules/discord/models/tautulli_activity_summary.py
@@ -16,13 +16,11 @@ class TautulliActivitySummary:
                  emoji_manager: EmojiManager,
                  text_manager: TextManager,
                  streams: List[TautulliStreamInfo] = None,
-                 has_plex_pass: bool = False,
                  error_occurred: bool = False,
                  additional_embed_fields: List[dict] = None,
                  additional_embed_footers: List[str] = None):
         self.activity = activity
         self.plex_online = plex_online
-        self.has_plex_pass = has_plex_pass
         self.error_occurred = error_occurred
         self.additional_embed_fields = additional_embed_fields or []
         self.additional_embed_footers = additional_embed_footers or []
@@ -48,8 +46,7 @@ class TautulliActivitySummary:
 
         footer_text = self._text_manager.overview_footer(no_connection=self.error_occurred,
                                                          activity=self.activity,
-                                                         emoji_manager=self._emoji_manager,
-                                                         add_termination_tip=self.has_plex_pass)
+                                                         emoji_manager=self._emoji_manager)
         if self.additional_embed_footers:
             footer_text += "\n"
         for additional_footer in self.additional_embed_footers:

--- a/modules/discord/services/live_activity.py
+++ b/modules/discord/services/live_activity.py
@@ -34,6 +34,7 @@ class LiveActivityMonitor(BaseService):
         self.admin_ids: list[int] = discord_settings.admin_ids
         self.refresh_time: int = tautulli_settings.refresh_interval_seconds
         self.use_summary_message: bool = discord_settings.use_summary_message
+        self.enable_stream_termination_if_possible: bool = discord_settings.enable_termination
         self.stats_settings: settings_models.Stats = stats_settings
         self.emoji_manager: EmojiManager = emoji_manager
         self.version_checker: versioning.VersionChecker = version_checker
@@ -117,6 +118,7 @@ class LiveActivityMonitor(BaseService):
                                                                tautulli_connector=self.tautulli,
                                                                guild_id=self.guild_id,
                                                                message=summary_message,
+                                                               enable_stream_termination_if_possible=self.enable_stream_termination_if_possible,
                                                                emoji_manager=self.emoji_manager,
                                                                version_checker=self.version_checker,
                                                                voice_category=activity_stats_voice_category)

--- a/modules/settings/config_parser.py
+++ b/modules/settings/config_parser.py
@@ -91,6 +91,7 @@ class DiscordConfig(ConfigSection):
         channel_name = self.get_value(key="ChannelName", default="tauticord")
         channel_name = utils.discord_text_channel_name_format(string=channel_name)
         use_summary_message = utils.extract_boolean(self.get_value(key="PostSummaryMessage", default=True))
+        enable_termination = utils.extract_boolean(self.get_value(key="EnableTermination", default=True))
         enable_slash_commands = utils.extract_boolean(self.get_value(key="EnableSlashCommands", default=False))
 
         status_message_settings_data = self.get_subsection_data(key="StatusMessage", optional=True)
@@ -102,6 +103,7 @@ class DiscordConfig(ConfigSection):
             admin_ids=admin_ids,
             channel_name=channel_name,
             use_summary_message=use_summary_message,
+            enable_termination=enable_termination,
             enable_slash_commands=enable_slash_commands,
             status_message_settings=status_message_settings
         )

--- a/modules/settings/models/discord.py
+++ b/modules/settings/models/discord.py
@@ -45,6 +45,7 @@ class Discord(BaseConfig):
     channel_name: str
     enable_slash_commands: bool
     use_summary_message: bool
+    enable_termination: bool
     server_id: int
     status_message_settings: StatusMessage
 
@@ -55,6 +56,7 @@ class Discord(BaseConfig):
             "channel_name": self.channel_name,
             "enable_slash_commands": self.enable_slash_commands,
             "use_summary_message": self.use_summary_message,
+            "enable_termination": self.enable_termination,
             "server_id": self.server_id,
             "status_message_settings": self.status_message_settings.as_dict()
         }

--- a/modules/tautulli/tautulli_connector.py
+++ b/modules/tautulli/tautulli_connector.py
@@ -57,7 +57,14 @@ class TautulliConnector:
         logging.error(error_message)
         self.analytics.event(event_category="Error", event_action=function_name, random_uuid_if_needed=True)
 
+    def plex_pass_feature_is_allowed(self, feature: bool) -> bool:
+        if not self.has_plex_pass:
+            return False
+
+        return feature
+
     def refresh_data(self,
+                     enable_stream_termination_if_possible: bool,
                      emoji_manager: EmojiManager,
                      additional_embed_fields: List[dict] = None,
                      additional_embed_footers: List[str] = None) -> TautulliActivitySummary:
@@ -67,6 +74,12 @@ class TautulliConnector:
         """
         # Erase session ID mappings from last refresh
         self.session_id_mappings = {}
+
+        # Add termination tip if enabled
+        if self.plex_pass_feature_is_allowed(feature=enable_stream_termination_if_possible):
+            additional_embed_footers = additional_embed_footers or []
+            additional_embed_footers.append(
+                f"To terminate a stream, react with the stream number.")
 
         data = self.api.activity()
 
@@ -88,7 +101,6 @@ class TautulliConnector:
                                            emoji_manager=emoji_manager,
                                            text_manager=self.text_manager,
                                            streams=session_details,
-                                           has_plex_pass=self.has_plex_pass,
                                            server_name=self.server_name,
                                            additional_embed_fields=additional_embed_fields,
                                            additional_embed_footers=additional_embed_footers)
@@ -100,7 +112,6 @@ class TautulliConnector:
                                        emoji_manager=emoji_manager,
                                        text_manager=self.text_manager,
                                        error_occurred=True,
-                                       has_plex_pass=False,  # Tautulli is unreachable, so we can't know check
                                        server_name=self.server_name,
                                        additional_embed_fields=additional_embed_fields,
                                        additional_embed_footers=additional_embed_footers)

--- a/modules/text_manager.py
+++ b/modules/text_manager.py
@@ -101,8 +101,7 @@ class TextManager(BaseModel):
         stubs = [stub for stub in stubs if stub is not None]
         return "\n".join(stubs)
 
-    def overview_footer(self, no_connection: bool, activity, emoji_manager: EmojiManager,
-                        add_termination_tip: bool) -> str:
+    def overview_footer(self, no_connection: bool, activity, emoji_manager: EmojiManager) -> str:
         timestamp = f"\n\nUpdated {self.time_manager.now_string()}"
 
         if no_connection or activity is None:
@@ -129,9 +128,6 @@ class TextManager(BaseModel):
                 lan_bandwidth = activity.lan_bandwidth
                 overview_message += f""" {lan_bandwidth_emoji} {lan_bandwidth}"""
 
-        overview_message += f"\n\n{timestamp}"
-
-        if add_termination_tip:
-            overview_message += f"\n\nTo terminate a stream, react with the stream number."
+        overview_message += f"{timestamp}\n"
 
         return overview_message

--- a/tauticord.yaml.example
+++ b/tauticord.yaml.example
@@ -26,6 +26,8 @@ Discord:
   PostSummaryMessage: true
   # The name of the channel where the live stats summary message will be posted
   ChannelName: "tautulli"
+  # Whether to enable termination capabilities (requires Plex Pass)
+  EnableTermination: true
   # Whether to enable slash commands
   EnableSlashCommands: true
   # Settings for the activity/status message


### PR DESCRIPTION
Users can now disable the termination reaction emojis independently of whether they have a Plex Pass. Setting will do nothing if user ultimately does not have a Plex Pass

Closes #216 