### PR TITLE
[chore] Add Tautulli v2.14 compatibility, drop v2.12 and v2.13 support

### DIFF
--- a/documentation/ANNOUNCEMENTS.md
+++ b/documentation/ANNOUNCEMENTS.md
@@ -14,6 +14,9 @@ release of Tautulli v2.14.0, which introduced breaking changes to the API.
 Because Tauticord enforces strict compatibility checking with Tautulli, the underlying `tautulli` API library will need
 to be updated to accommodate v2.14.0. Doing so will drop v2.12.x and v2.13.x support at the same time.
 
+If you need to continue using Tauticord with Tautulli versions v2.12.x or v2.13.x, you will need to pin your Tauticord 
+version to an earlier version using Docker tags: https://hub.docker.com/r/nwithan8/tauticord/tags
+
 ---
 
 ## Removing Environmental Variables in Unraid Community Applications Template

--- a/documentation/ANNOUNCEMENTS.md
+++ b/documentation/ANNOUNCEMENTS.md
@@ -4,7 +4,7 @@
 
 **Latest Release**: *v5.3.4*
 
-**Affected Release**: *v5.x.0+*
+**Affected Release**: *v5.5.0+*
 
 **Affected Users**: Those using Tauticord with Tautulli versions v2.12.x and v2.13.x
 
@@ -32,9 +32,8 @@ variables.
 Instead, Tauticord will be configured using a `tauticord.yaml` file located in the `/config` directory.
 
 `v4.2.0` and `v4.2.1` of Tauticord include a built-in migration system that automatically converts existing
-environmental
-variable configurations to a YAML configuration file. The bot still operates using environmental variables; the
-migration output will be used by additional migrations in the upcoming `v5.0.0` release.
+environmental variable configurations to a YAML configuration file. The bot still operates using environmental 
+variables; the migration output will be used by additional migrations in the upcoming `v5.0.0` release.
 
 As a result, the **Unraid Community Applications** template will no longer include the option to configure Tauticord
 using environmental variables. The template already requires users to provide a `/config` directory path mapping, so

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -3,8 +3,7 @@
 ## Compatibility
 
 Tauticord is compatible with the following versions of Tautulli:
-- v2.12.x
-- v2.13.x
+- v2.14.x
 
 ## Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py==2.3.*
 asyncio~=3.4
-tautulli==4.0.*,>=4.0.0.2120
+tautulli==4.2.*,>=4.2.0.2140b0
 confuse==2.0.1
 PyYAML==6.0.*
 objectrest~=2.0.0


### PR DESCRIPTION
Bump `tautulli` dependency, which drops Tautulli v2.13 and v2.14 support due to breaking API changes.