### PR TITLE
[fix] Account for Plex Pass requirement for CPU and RAM stats feature (#233, #227)

### DIFF
--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -227,8 +227,8 @@ updates).
 
 Performance monitoring will report metrics such as:
 
-- CPU usage
-- RAM usage
+- CPU usage (requires Plex Pass)
+- RAM usage (requires Plex Pass)
 - Disk space usage
 - Plex user count
 
@@ -254,6 +254,17 @@ report "N/A".
 Please be aware of the potential risks of allowing raw SQL queries to be run directly on your Tautulli database via the
 API. If you do not intend on using the performance monitoring feature, it is recommended to keep SQL queries
 disabled (`api_sql = 0` in Tautulli's `config.ini` file).
+
+#### CPU and RAM Monitoring
+
+Tauticord's CPU and RAM monitoring features will [directly communicate with the Plex Media Server](#system-access) to
+retrieve statistics. CPU and RAM usage statistics is
+a [Plex Pass feature](https://support.plex.tv/articles/200871837-status-and-dashboard/); as a result, this requires a
+Plex Pass subscription to work.
+
+Tauticord will automatically determine if the Plex Media Server has a Plex Pass subscription. If this feature is enabled
+in the configuration file, but the Plex Media Server does not have a Plex Pass subscription, Tauticord will ignore the
+configuration settings and log a warning.
 
 #### Disk Space Monitoring
 
@@ -301,9 +312,11 @@ Variants:
 
 **This command is locked to administrators only.**
 
-Display graphs for Tautulli play count/duration statistics. This is similar to the "Graphs" section on the Tautulli homepage.
+Display graphs for Tautulli play count/duration statistics. This is similar to the "Graphs" section on the Tautulli
+homepage.
 
 Variants:
+
 - `/graphs play-count-daily`
 - `/graphs play-count-day-of-week`
 - `/graphs play-count-hour-of-day`

--- a/modules/settings/config_parser.py
+++ b/modules/settings/config_parser.py
@@ -84,7 +84,7 @@ class DiscordConfig(ConfigSection):
         channel_name = self.get_value(key="ChannelName", default="tauticord")
         channel_name = utils.discord_text_channel_name_format(string=channel_name)
         use_summary_message = utils.extract_boolean(self.get_value(key="PostSummaryMessage", default=True))
-        enable_termination = utils.extract_boolean(self.get_value(key="EnableTermination", default=True))
+        enable_termination = utils.extract_boolean(self.get_value(key="EnableTermination", default=False))
         enable_slash_commands = utils.extract_boolean(self.get_value(key="EnableSlashCommands", default=False))
 
         status_message_settings_data = self.get_subsection_data(key="StatusMessage", optional=True)

--- a/modules/tasks/activity.py
+++ b/modules/tasks/activity.py
@@ -160,7 +160,8 @@ class ActivityStatsAndSummaryMessage(VoiceCategoryStatsMonitor):
         # update the message regardless of whether the content has changed
         self.message = await discord_utils.send_embed_message(embed=summary.embed, message=self.message)
 
-        if self.tautulli.plex_pass_feature_is_allowed(feature=self.enable_stream_termination_if_possible):
+        if self.tautulli.plex_pass_feature_is_allowed(feature=self.enable_stream_termination_if_possible,
+                                                      warning="Stream termination control requires Plex Pass, ignoring setting..."):
             await self.add_stream_number_emoji_reactions(count=len(summary.streams),
                                                          emoji_manager=self.emoji_manager)
             # on_raw_reaction_add will handle the rest

--- a/modules/tasks/performance_stats.py
+++ b/modules/tasks/performance_stats.py
@@ -90,14 +90,16 @@ class PerformanceMonitor(VoiceCategoryStatsMonitor):
             await self.edit_stat_voice_channel(voice_channel_settings=settings,
                                                stat=stat)
 
-        if self.stats_settings.cpu.enable:
+        if self.tautulli.plex_pass_feature_is_allowed(feature=self.stats_settings.cpu.enable,
+                                                      warning="CPU usage stats require Plex Pass, ignoring setting..."):
             settings = self.stats_settings.cpu
             cpu_percent = self.calculate_cpu_percent()
             logging.debug(f"Updating CPU voice channel with new CPU percent: {cpu_percent}")
             await self.edit_stat_voice_channel(voice_channel_settings=settings,
                                                stat=cpu_percent)
 
-        if self.stats_settings.memory.enable:
+        if self.tautulli.plex_pass_feature_is_allowed(feature=self.stats_settings.memory.enable,
+                                                      warning="Memory usage stats require Plex Pass, ignoring setting..."):
             settings = self.stats_settings.memory
             memory_percent = self.calculate_memory_percent()
             logging.debug(f"Updating Memory voice channel with new Memory percent: {memory_percent}")

--- a/modules/tautulli/tautulli_connector.py
+++ b/modules/tautulli/tautulli_connector.py
@@ -62,8 +62,10 @@ class TautulliConnector:
         logging.error(error_message)
         self.analytics.event(event_category="Error", event_action=function_name, random_uuid_if_needed=True)
 
-    def plex_pass_feature_is_allowed(self, feature: bool) -> bool:
+    def plex_pass_feature_is_allowed(self, feature: bool, warning: Optional[str] = None) -> bool:
         if not self.has_plex_pass:
+            if feature and warning:  # Only log warning if feature was attempted to be used
+                logging.warning(warning)
             return False
 
         return feature
@@ -345,7 +347,8 @@ class TautulliConnector:
 
         match chart_type:
             case StatChartType.DAILY_BY_MEDIA_TYPE:
-                data = self.api.get_plays_by_date(time_range=days, y_axis=StatMetricType.DURATION.value, user_ids=user_ids)
+                data = self.api.get_plays_by_date(time_range=days, y_axis=StatMetricType.DURATION.value,
+                                                  user_ids=user_ids)
             case StatChartType.BY_HOUR_OF_DAY:
                 data = self.api.get_plays_by_hour_of_day(time_range=days, y_axis=StatMetricType.DURATION.value,
                                                          user_ids=user_ids)


### PR DESCRIPTION
- Check for Plex Pass before attempting CPU and RAM usage monitoring
- Log warning for features that couldn't be enabled due to missing Plex Pass
- Disable termination feature by default (avoid Plex Pass issues)
- Update documentation re: Plex Pass requirement for CPU and RAM usage monitoring

Closes #232 

Closes #227 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated compatibility section to specify support for Tautulli v2.14.x.
	- Expanded requirements section to include "Message Content Intent" for slash commands.
	- Refined configuration section to clarify mandatory variables in `tauticord.yaml`.
	- Enhanced performance monitoring details regarding Plex Pass subscription requirements.
	- Clarified commands section, particularly for the `/graphs` command.
	- Expanded analytics section to detail data collection practices.

- **Bug Fixes**
	- Adjusted default behavior for the termination feature in Discord configuration.

- **Improvements**
	- Enhanced logging for stream termination control and performance monitoring checks related to Plex Pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->