### PR TITLE
[chore] Add Tautulli v2.15.0 support, drop v2.14.0 and v2.14.1 support

### DIFF
--- a/documentation/ANNOUNCEMENTS.md
+++ b/documentation/ANNOUNCEMENTS.md
@@ -1,3 +1,27 @@
+## Dropping Support for v2.14.0 and v2.14.1 of Tautulli
+
+**Date Posted**: 2024-11-24
+
+**Latest Release**: *v5.7.3*
+
+**Affected Release**: *v5.8.0+*
+
+**Affected Users**: Those using Tauticord with Tautulli versions v2.14.0 and v2.14.1
+
+An upcoming minor release of Tauticord will drop support for Tautulli versions v2.14.0 and v2.14.1. This is due to the
+minimum required API version of the `tautulli` API library, which has been updated.
+
+Tautulli v2.14.0 and v2.14.1 were technically beta releases of Tautulli v2.14.X, and did not play nicely with the 
+minimum API version enforcement capabilities of the `tautulli` API library (which are enforced by Tauticord).
+
+Any users still running Tautulli v2.14.0 or v2.14.1 should upgrade to a newer version of Tautulli to continue using
+Tauticord.
+
+If you need to continue using Tauticord with Tautulli versions v2.14.0 or v2.14.1, you will need to pin your Tauticord
+version to an earlier version using Docker tags: https://hub.docker.com/r/nwithan8/tauticord/tags
+
+---
+
 ## Dropping Support for v2.12.x and v2.13.x of Tautulli
 
 **Date Posted**: 2024-04-19

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -4,7 +4,7 @@
 
 Tauticord is compatible with the following versions of Tautulli:
 
-- v2.14.x
+- v2.14.2 and above
 
 ## Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py==2.3.*
 asyncio~=3.4
-tautulli==4.3.*,>=4.2.0.2140b0
+tautulli==4.4.*,>=4.4.0.2142
 confuse==2.0.1
 PyYAML==6.0.*
 objectrest~=2.0.0


### PR DESCRIPTION
- Bump `tautulli` dependency
- Add Tautulli v2.15.0 support
- Drop Tautulli v2.14.0 and v2.14.1 support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a section on dropping support for Tautulli versions v2.14.0 and v2.14.1 in the announcements.
	- Updated compatibility information to specify Tautulli version 2.14.2 and above.
	- Clarified installation requirements and risks associated with SQL queries in Tautulli's API.
	- Enhanced details on running Tauticord exclusively as a Docker container and provided YAML validation guidance.
	- Expanded descriptions of available statistics in voice channels and command accessibility. 

- **Chores**
	- Updated package dependencies to require a newer version of the Tautulli package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->