### PR TITLE
Account for missing media type (e.g. music) when generating graphs

### DIFF
--- a/modules/discord/commands/graphs.py
+++ b/modules/discord/commands/graphs.py
@@ -75,7 +75,7 @@ class Graphs(commands.GroupCog, name="graphs"):
                                        metric: StatMetricType,
                                        days: int,
                                        chart_builder_function: Callable[
-                                           [PlayCountStats | PlayDurationStats, str], ChartMaker],
+                                           [PlayCountStats | PlayDurationStats, str], ChartMaker | None],
                                        username: str = None,
                                        share: Optional[bool] = False) -> None:
         passed_admin_check: bool = await self.check_admin(interaction)
@@ -135,7 +135,10 @@ class Graphs(commands.GroupCog, name="graphs"):
         if username:
             chart_title: str = f"{chart_title} for {username}"
 
-        chart_marker: ChartMaker = chart_builder_function(stats, chart_title)
+        chart_marker: ChartMaker | None = chart_builder_function(stats, chart_title)
+        if not chart_marker:
+            await interaction.response.send_message("Error occurred when generating chart.", ephemeral=True)
+            return
 
         parent_chart_path = get_current_directory() if not is_docker() else None
         chart_path: str = utils.get_temporary_file_path(sub_directory="charts", parent_directory=parent_chart_path,
@@ -155,12 +158,19 @@ class Graphs(commands.GroupCog, name="graphs"):
                                days: int,
                                username: Optional[str] = None,
                                share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker:
-            tv_show_data = stats.tv_shows
+        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker | None:
+            tv_show_data = stats.tv_shows  # Will always be a PlayStatsCategoryData object, but potentially [] values
             movie_data = stats.movies
             music_data = stats.music
-            chart_maker = ChartMaker(x_axis=tv_show_data.x_axis,
-                                     x_axis_labels=tv_show_data.x_axis,
+
+            x_axis = tv_show_data.x_axis or movie_data.x_axis or music_data.x_axis  # Potentially []
+            x_axis_labels = tv_show_data.x_axis or movie_data.x_axis or music_data.x_axis  # Potentially []
+
+            if not x_axis or not x_axis_labels:
+                return None
+
+            chart_maker = ChartMaker(x_axis=x_axis,
+                                     x_axis_labels=x_axis_labels,
                                      title=title,
                                      background_color=StatChartColors.BACKGROUND.value,
                                      text_color=StatChartColors.TEXT.value,
@@ -210,10 +220,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                      days: int,
                                      username: Optional[str] = None,
                                      share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -254,10 +265,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                      days: int,
                                      username: Optional[str] = None,
                                      share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -299,10 +311,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                    days: int,
                                    username: Optional[str] = None,
                                    share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -341,10 +354,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                interaction: discord.Interaction,
                                days: int,
                                share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayCountStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -385,12 +399,19 @@ class Graphs(commands.GroupCog, name="graphs"):
                                   days: int,
                                   username: Optional[str] = None,
                                   share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
-            chart_maker = ChartMaker(x_axis=tv_show_data.x_axis,
-                                     x_axis_labels=tv_show_data.x_axis,
+
+            x_axis = tv_show_data.x_axis or movie_data.x_axis or music_data.x_axis
+            x_axis_labels = tv_show_data.x_axis or movie_data.x_axis or music_data.x_axis
+
+            if not x_axis or not x_axis_labels:
+                return None
+
+            chart_maker = ChartMaker(x_axis=x_axis,
+                                     x_axis_labels=x_axis_labels,
                                      title=title,
                                      background_color=StatChartColors.BACKGROUND.value,
                                      text_color=StatChartColors.TEXT.value,
@@ -441,10 +462,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                         days: int,
                                         username: Optional[str] = None,
                                         share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -486,10 +508,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                         days: int,
                                         username: Optional[str] = None,
                                         share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -531,10 +554,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                       days: int,
                                       username: Optional[str] = None,
                                       share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,
@@ -574,10 +598,11 @@ class Graphs(commands.GroupCog, name="graphs"):
                                   interaction: discord.Interaction,
                                   days: int,
                                   share: Optional[bool] = False) -> None:
-        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker:
+        def chart_builder_function(stats: PlayDurationStats, title: str) -> ChartMaker | None:
             tv_show_data = stats.tv_shows
             movie_data = stats.movies
             music_data = stats.music
+
             chart_maker = ChartMaker(x_axis=stats.categories,
                                      x_axis_labels=stats.categories,
                                      title=title,

--- a/modules/tautulli/models/stats.py
+++ b/modules/tautulli/models/stats.py
@@ -11,7 +11,7 @@ class PlayStats:
         self.categories: list = data.get('categories', [])
         self._series: list[dict] = data.get('series', [])
 
-    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData | None:
+    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData:
         raise NotImplementedError
 
     @property
@@ -23,15 +23,15 @@ class PlayStats:
         }
 
     @property
-    def tv_shows(self) -> PlayStatsCategoryData | None:
+    def tv_shows(self) -> PlayStatsCategoryData:
         return self._get_category_data(category_name='TV')
 
     @property
-    def movies(self) -> PlayStatsCategoryData | None:
+    def movies(self) -> PlayStatsCategoryData:
         return self._get_category_data(category_name='Movies')
 
     @property
-    def music(self) -> PlayStatsCategoryData | None:
+    def music(self) -> PlayStatsCategoryData:
         return self._get_category_data(category_name='Music')
 
 
@@ -39,7 +39,7 @@ class PlayCountStats(PlayStats):
     def __init__(self, data: dict):
         super().__init__(data=data)
 
-    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData | None:
+    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData:
         for series in self._series:
             if series.get('name', None) == category_name:
                 return PlayStatsCategoryData(
@@ -48,14 +48,18 @@ class PlayCountStats(PlayStats):
                     values=series.get('data', [])
                 )
 
-        return None
+        return PlayStatsCategoryData(
+            category_name=category_name,
+            x_axis=self.categories,
+            values=[]
+        )
 
 
 class PlayDurationStats(PlayStats):
     def __init__(self, data: dict):
         super().__init__(data=data)
 
-    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData | None:
+    def _get_category_data(self, category_name: str) -> PlayStatsCategoryData:
         for series in self._series:
             if series.get('name', None) == category_name:
                 return PlayStatsCategoryData(
@@ -64,4 +68,8 @@ class PlayDurationStats(PlayStats):
                     values=series.get('data', [])
                 )
 
-        return None
+        return PlayStatsCategoryData(
+            category_name=category_name,
+            x_axis=self.categories,
+            values=[]
+        )


### PR DESCRIPTION
Closes #240 

Need to provide a dummy `PlayStatsCategoryData` if no libraries for a media type (e.g. music) exist when generating graphs (will have empty array as values, which will simply cause no data to be plotted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - **Enhanced chart generation:** Users now receive clear error notifications when a chart cannot be built due to incomplete data, preventing unexpected behavior during display.
  - **Reliable performance summaries:** Statistical insights are now consistently complete and accurate, ensuring that all performance metrics are shown reliably.
  - These updates enhance overall system stability, resulting in a smoother and more predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->