### PR TITLE
Normalize channel names when comparing against prefixes

### DIFF
--- a/modules/discord/discord_utils.py
+++ b/modules/discord/discord_utils.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional
 import discord
 
 import modules.logs as logging
-from modules.utils import quote
+from modules.utils import quote, strip_phantom_space
 
 
 async def get_guild(client: discord.Client, guild_id: int) -> discord.Guild:
@@ -118,11 +118,12 @@ async def get_or_create_discord_channel_by_starting_name(client: discord.Client,
                                                          channel_type: discord.ChannelType,
                                                          category: discord.CategoryChannel = None) -> \
         Union[discord.VoiceChannel, discord.TextChannel, None]:
+    starting_channel_name_normalized = normalize_channel_name(channel_name=starting_channel_name)
     channels = await get_all_discord_channels(client=client, guild_id=guild_id, channel_type=channel_type)
     for channel in channels:
-        name = channel.name.strip()  # Phantom spaces are the worst
+        name_normalized = normalize_channel_name(channel_name=channel.name)
 
-        if name.startswith(starting_channel_name):
+        if name_normalized.startswith(starting_channel_name_normalized):
             if category and channel.category != category:
                 continue
             return channel
@@ -234,3 +235,16 @@ def is_valid_reaction(reaction_emoji: discord.PartialEmoji,
     if valid_user_ids and reaction_user_id not in valid_user_ids:
         return False
     return True
+
+
+def normalize_channel_name(channel_name: str) -> str:
+    """
+    Normalize a Discord channel name.
+    :param channel_name: The original channel name
+    :return: Normalized channel name
+    """
+    channel_name = channel_name.strip()  # Remove leading and trailing spaces
+    channel_name = strip_phantom_space(string=channel_name)  # Remove phantom spaces
+    channel_name = channel_name.replace(" ", "")  # Remove any weird space characters in the name
+    channel_name = channel_name.lower()
+    return channel_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py==2.3.*
+discord.py==2.5.*
 asyncio~=3.4
 tautulli==4.6.*,>=4.6.0.2142
 confuse==2.0.1


### PR DESCRIPTION
On May 29, 2025, the Discord API began returning voice channel names with slight inconsistencies for space characters, which resulted in failed voice channel fetching and subsequent duplicate voice channels being created.

This PR implements a `normalize_channel_name` that both the channel name and the compared-against channel prefix are passed through prior to comparison, in an effort to remove stray and inconsistent characters and avoid false negative comparisons.

This PR also bumps the `discord.py` dependency from 2.3.* to 2.5.*, as the last 2.3.* release was in 2023.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when matching Discord channel names, ensuring more reliable channel selection regardless of spacing or capitalization.

- **Chores**
  - Updated the required version of the Discord package to 2.5.* for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->