### PR TITLE
Drop Tautulli v2.16.x support

### DIFF
--- a/documentation/ANNOUNCEMENTS.md
+++ b/documentation/ANNOUNCEMENTS.md
@@ -1,3 +1,24 @@
+## Dropping Support for v2.16.x and older of Tautulli
+
+**Date Posted**: 2026-03-27
+
+**Latest Release**: *v5.15.2*
+
+**Affected Release**: *v5.16.0+*
+
+**Affected Users**: Those using Tauticord with Tautulli versions v2.16.x and older.
+
+An upcoming minor release of Tauticord will drop support for Tautulli versions v2.16.x and older. This is due to the
+minimum required API version of the `tautulli` API library, which has been updated.
+
+Any users still running Tautulli v2.16.x or earlier should upgrade to a newer version of Tautulli to continue using
+Tauticord.
+
+If you need to continue using Tauticord with earlier Tautulli versions, you will need to pin your Tauticord
+version to an earlier version using Docker tags: https://hub.docker.com/r/nwithan8/tauticord/tags
+
+--
+
 ## Dropping Support for v2.14.0 and v2.14.1 of Tautulli
 
 **Date Posted**: 2024-11-24

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -4,7 +4,7 @@
 
 Tauticord is compatible with the following versions of Tautulli:
 
-- v2.14.2 and above
+- v2.17.0 and above
 
 ## Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py==2.5.*
 asyncio~=3.4
-tautulli==4.6.*,>=4.6.0.2142
+tautulli==4.7.*,>=4.7.0.2170
 confuse==2.0.1
 PyYAML==6.0.*
 objectrest~=2.0.0


### PR DESCRIPTION
- Bump `tautulli` dependency 
- Announce support level change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added announcement about dropping support for Tautulli v2.16.x and older in an upcoming release.
  * Updated minimum Tautulli compatibility requirement to v2.17.0 or above.
  * Users running older Tautulli versions must upgrade or pin to an earlier Docker image tag to continue using the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->